### PR TITLE
Implement "bind" configuration in KeyMap

### DIFF
--- a/include/keymap.h
+++ b/include/keymap.h
@@ -196,6 +196,7 @@ public:
 	std::vector<KeyMapDesc> get_keymap_descriptions(std::string context);
 
 	ParsedOperations parse_operation_sequence(const std::string& line);
+	std::string parse_operation_description(const std::string& input);
 	std::vector<MacroCmd> get_startup_operation_sequence();
 
 private:

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -2,6 +2,7 @@
 #define NEWSBOAT_KEYMAP_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -180,6 +181,17 @@ struct Key {
 	bool shift;
 	bool control;
 	bool meta;
+};
+
+struct Binding {
+};
+
+struct KeyBinding : Binding {
+	std::map<Key, std::shared_ptr<Binding>> bindings;
+};
+
+struct OperationsBinding : Binding {
+	std::vector<MacroCmd> operations;
 };
 
 class KeyMap : public ConfigActionHandler {

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -170,6 +170,11 @@ struct MacroCmd {
 	std::vector<std::string> args;
 };
 
+struct ParsedOperations {
+	std::vector<MacroCmd> operations;
+	std::string leftovers;
+};
+
 class KeyMap : public ConfigActionHandler {
 public:
 	explicit KeyMap(unsigned int flags);
@@ -190,7 +195,7 @@ public:
 	void dump_config(std::vector<std::string>& config_output) const override;
 	std::vector<KeyMapDesc> get_keymap_descriptions(std::string context);
 
-	std::vector<MacroCmd> parse_operation_sequence(const std::string& line);
+	ParsedOperations parse_operation_sequence(const std::string& line);
 	std::vector<MacroCmd> get_startup_operation_sequence();
 
 private:

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -192,6 +192,7 @@ struct KeyBinding : Binding {
 
 struct OperationsBinding : Binding {
 	std::vector<MacroCmd> operations;
+	std::string description;
 };
 
 class KeyMap : public ConfigActionHandler {
@@ -224,8 +225,12 @@ private:
 	unsigned short get_flag_from_context(const std::string& context);
 	std::map<std::string, Operation> get_internal_operations() const;
 	std::string getopname(Operation op) const;
+	void register_binding(const std::string& context, std::vector<Key> key_sequence,
+		std::vector<MacroCmd> operations, const std::string description);
+
 	std::map<std::string, std::map<std::string, Operation>> keymap_;
 	std::map<std::string, std::vector<MacroCmd>> macros_;
+	std::map<std::string, std::shared_ptr<OperationsBinding>> bindings_;
 	std::vector<MacroCmd> startup_operations_sequence;
 };
 

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -183,16 +183,22 @@ struct Key {
 	bool meta;
 };
 
+bool operator<(const Key& l, const Key& r);
+
 struct Binding {
+	virtual ~Binding() = default;
 };
 
-struct KeyBinding : Binding {
+struct KeyBinding : public Binding {
 	std::map<Key, std::shared_ptr<Binding>> bindings;
 };
 
-struct OperationsBinding : Binding {
+struct OperationsBinding : public Binding {
 	std::vector<MacroCmd> operations;
 	std::string description;
+
+	OperationsBinding(const std::vector<MacroCmd>& o,
+		const std::string& d) : operations(o), description(d) {};
 };
 
 class KeyMap : public ConfigActionHandler {
@@ -225,12 +231,13 @@ private:
 	unsigned short get_flag_from_context(const std::string& context);
 	std::map<std::string, Operation> get_internal_operations() const;
 	std::string getopname(Operation op) const;
-	void register_binding(const std::string& context, std::vector<Key> key_sequence,
+	void register_binding(const std::string& context, std::vector<Key> key_prefix,
+		Key key,
 		std::vector<MacroCmd> operations, const std::string description);
 
 	std::map<std::string, std::map<std::string, Operation>> keymap_;
 	std::map<std::string, std::vector<MacroCmd>> macros_;
-	std::map<std::string, std::shared_ptr<OperationsBinding>> bindings_;
+	std::map<std::string, std::shared_ptr<KeyBinding>> bindings_;
 	std::vector<MacroCmd> startup_operations_sequence;
 };
 

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -175,6 +175,13 @@ struct ParsedOperations {
 	std::string leftovers;
 };
 
+struct Key {
+	std::string key;
+	bool shift;
+	bool control;
+	bool meta;
+};
+
 class KeyMap : public ConfigActionHandler {
 public:
 	explicit KeyMap(unsigned int flags);
@@ -197,6 +204,7 @@ public:
 
 	ParsedOperations parse_operation_sequence(const std::string& line);
 	std::string parse_operation_description(const std::string& input);
+	std::vector<Key> parse_key_sequence(const std::string& input);
 	std::vector<MacroCmd> get_startup_operation_sequence();
 
 private:

--- a/rust/libnewsboat-ffi/src/keymap.rs
+++ b/rust/libnewsboat-ffi/src/keymap.rs
@@ -15,7 +15,7 @@ mod ffi {
         // This is not very elegant, but doing the same by hand using `extern "C"` is prohibitively
         // complex.
         type Operation;
-        fn tokenize_operation_sequence(input: &str) -> Vec<Operation>;
+        fn tokenize_operation_sequence(input: &str, leftovers: &mut String) -> Vec<Operation>;
         fn operation_tokens(operation: &Operation) -> &Vec<String>;
     }
 
@@ -33,12 +33,15 @@ struct Operation {
     tokens: Vec<String>,
 }
 
-fn tokenize_operation_sequence(input: &str) -> Vec<Operation> {
+fn tokenize_operation_sequence(input: &str, leftovers: &mut String) -> Vec<Operation> {
     match libnewsboat::keymap::tokenize_operation_sequence(input) {
-        Some(operations) => operations
-            .into_iter()
-            .map(|tokens| Operation { tokens })
-            .collect::<Vec<_>>(),
+        Some((operations, remainder)) => {
+            *leftovers = remainder.to_string();
+            operations
+                .into_iter()
+                .map(|tokens| Operation { tokens })
+                .collect::<Vec<_>>()
+        }
         None => vec![],
     }
 }

--- a/rust/libnewsboat-ffi/src/keymap.rs
+++ b/rust/libnewsboat-ffi/src/keymap.rs
@@ -17,6 +17,8 @@ mod ffi {
         type Operation;
         fn tokenize_operation_sequence(input: &str, leftovers: &mut String) -> Vec<Operation>;
         fn operation_tokens(operation: &Operation) -> &Vec<String>;
+
+        fn tokenize_operation_description(input: &str) -> String;
     }
 
     extern "C++" {
@@ -48,4 +50,11 @@ fn tokenize_operation_sequence(input: &str, leftovers: &mut String) -> Vec<Opera
 
 fn operation_tokens(input: &Operation) -> &Vec<String> {
     &input.tokens
+}
+
+fn tokenize_operation_description(input: &str) -> String {
+    match libnewsboat::keymap::tokenize_operation_description(input) {
+        Some(description) => String::from(description),
+        None => String::new(),
+    }
 }

--- a/rust/libnewsboat-ffi/src/keymap.rs
+++ b/rust/libnewsboat-ffi/src/keymap.rs
@@ -19,6 +19,13 @@ mod ffi {
         fn operation_tokens(operation: &Operation) -> &Vec<String>;
 
         fn tokenize_operation_description(input: &str) -> String;
+
+        type Key;
+        fn tokenize_key_sequence(input: &str) -> Vec<Key>;
+        fn get_key(key: &Key) -> String;
+        fn get_shift(key: &Key) -> bool;
+        fn get_control(key: &Key) -> bool;
+        fn get_meta(key: &Key) -> bool;
     }
 
     extern "C++" {
@@ -33,6 +40,13 @@ mod ffi {
 
 struct Operation {
     tokens: Vec<String>,
+}
+
+struct Key {
+    key: String,
+    shift: bool,
+    control: bool,
+    meta: bool,
 }
 
 fn tokenize_operation_sequence(input: &str, leftovers: &mut String) -> Vec<Operation> {
@@ -57,4 +71,34 @@ fn tokenize_operation_description(input: &str) -> String {
         Some(description) => String::from(description),
         None => String::new(),
     }
+}
+
+fn tokenize_key_sequence(input: &str) -> Vec<Key> {
+    match libnewsboat::keymap::tokenize_key_sequence(input) {
+        Some(key_sequence) => key_sequence
+            .into_iter()
+            .map(|k| Key {
+                key: k.key,
+                shift: k.shift,
+                control: k.control,
+                meta: k.meta,
+            })
+            .collect(),
+        None => vec![],
+    }
+}
+
+fn get_key(key: &Key) -> String {
+    key.key.to_owned()
+}
+fn get_shift(key: &Key) -> bool {
+    key.shift
+}
+
+fn get_control(key: &Key) -> bool {
+    key.control
+}
+
+fn get_meta(key: &Key) -> bool {
+    key.meta
 }

--- a/rust/libnewsboat/src/keymap.rs
+++ b/rust/libnewsboat/src/keymap.rs
@@ -57,6 +57,17 @@ fn operation_sequence(input: &str) -> IResult<&str, Vec<Vec<String>>> {
     parser(input)
 }
 
+fn operation_description(input: &str) -> IResult<&str, &str> {
+    let start_token = delimited(space0, tag("--"), space0);
+
+    let double_quote = tag("\"");
+    let parser = delimited(&double_quote, recognize(is_not("\"")), &double_quote);
+
+    let mut parser = preceded(start_token, parser);
+
+    parser(input)
+}
+
 /// Split a semicolon-separated list of operations into a vector. Each operation is represented by
 /// a non-empty sub-vector, where the first element is the name of the operation, and the rest of
 /// the elements are operation's arguments.
@@ -77,8 +88,16 @@ pub fn tokenize_operation_sequence(input: &str) -> Option<(Vec<Vec<String>>, &st
     }
 }
 
+pub fn tokenize_operation_description(input: &str) -> Option<&str> {
+    match operation_description(input) {
+        Ok((_leftovers, description)) => Some(description),
+        Err(_error) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::tokenize_operation_description;
     use super::tokenize_operation_sequence;
 
     #[test]
@@ -332,5 +351,50 @@ mod tests {
             vec![vec!["set", "a", "b", "--", "name of function"]]
         );
         assert_eq!(leftover, "");
+    }
+
+    #[test]
+    fn t_tokenize_operation_description_supports_empty_input() {
+        assert_eq!(tokenize_operation_description(""), None);
+    }
+
+    #[test]
+    fn t_tokenize_operation_description_ignores_preceding_spaces() {
+        assert_eq!(
+            tokenize_operation_description(r#"-- "description""#).unwrap(),
+            "description"
+        );
+        assert_eq!(
+            tokenize_operation_description(r#"     -- "description""#).unwrap(),
+            "description"
+        );
+    }
+
+    #[test]
+    fn t_tokenize_operation_description_ignores_trailing_spaces() {
+        assert_eq!(
+            tokenize_operation_description(r#"-- "description"   "#).unwrap(),
+            "description"
+        );
+    }
+
+    #[test]
+    fn t_tokenize_operation_description_includes_whitespace() {
+        assert_eq!(
+            tokenize_operation_description(r#"-- "multi-word description""#).unwrap(),
+            "multi-word description"
+        );
+        assert_eq!(
+            tokenize_operation_description(r#"-- "  leading and trailing  ""#).unwrap(),
+            "  leading and trailing  "
+        );
+    }
+
+    #[test]
+    fn t_tokenize_operation_description_requires_closing_quote() {
+        assert_eq!(
+            tokenize_operation_description(r#"-- "description not closed "#),
+            None
+        );
     }
 }

--- a/rust/libnewsboat/src/keymap.rs
+++ b/rust/libnewsboat/src/keymap.rs
@@ -4,7 +4,7 @@ use nom::{
     character::complete::{space0, space1},
     combinator::{complete, eof, map, recognize, value},
     multi::{many0, many1, separated_list0, separated_list1},
-    sequence::delimited,
+    sequence::{delimited, preceded},
     IResult,
 };
 
@@ -49,6 +49,7 @@ fn semicolon(input: &str) -> IResult<&str, &str> {
 fn operation_sequence(input: &str) -> IResult<&str, Vec<Vec<String>>> {
     let parser = separated_list0(many1(semicolon), operation_with_args);
     let parser = delimited(many0(semicolon), parser, many0(semicolon));
+    let parser = preceded(space0, parser);
 
     let mut parser = complete(parser);
 

--- a/rust/libnewsboat/src/keymap.rs
+++ b/rust/libnewsboat/src/keymap.rs
@@ -70,9 +70,9 @@ fn operation_sequence(input: &str) -> IResult<&str, Vec<Vec<String>>> {
 /// 2. doesn't contain backticks that need to be processed.
 ///
 /// Returns `None` if the input could not be parsed.
-pub fn tokenize_operation_sequence(input: &str) -> Option<Vec<Vec<String>>> {
+pub fn tokenize_operation_sequence(input: &str) -> Option<(Vec<Vec<String>>, &str)> {
     match operation_sequence(input) {
-        Ok((_leftovers, tokens)) => Some(tokens),
+        Ok((leftovers, tokens)) => Some((tokens, leftovers)),
         Err(_error) => None,
     }
 }
@@ -84,56 +84,69 @@ mod tests {
     #[test]
     fn t_tokenize_operation_sequence_works_for_all_cpp_inputs() {
         assert_eq!(
-            tokenize_operation_sequence("").unwrap(),
+            tokenize_operation_sequence("").unwrap().0,
             Vec::<Vec<String>>::new()
         );
         assert_eq!(
-            tokenize_operation_sequence("open").unwrap(),
+            tokenize_operation_sequence("open").unwrap().0,
             vec![vec!["open"]]
         );
         assert_eq!(
-            tokenize_operation_sequence("open-all-unread-in-browser-and-mark-read").unwrap(),
+            tokenize_operation_sequence("open-all-unread-in-browser-and-mark-read")
+                .unwrap()
+                .0,
             vec![vec!["open-all-unread-in-browser-and-mark-read"]]
         );
         assert_eq!(
-            tokenize_operation_sequence("; ; ; ;").unwrap(),
+            tokenize_operation_sequence("; ; ; ;").unwrap().0,
             Vec::<Vec<String>>::new()
         );
         assert_eq!(
-            tokenize_operation_sequence("open ; next").unwrap(),
+            tokenize_operation_sequence("open ; next").unwrap().0,
             vec![vec!["open"], vec!["next"]]
         );
         assert_eq!(
-            tokenize_operation_sequence("open ; next ; prev").unwrap(),
+            tokenize_operation_sequence("open ; next ; prev").unwrap().0,
             vec![vec!["open"], vec!["next"], vec!["prev"]]
         );
         assert_eq!(
-            tokenize_operation_sequence("open ; next ; prev ; quit").unwrap(),
+            tokenize_operation_sequence("open ; next ; prev ; quit")
+                .unwrap()
+                .0,
             vec![vec!["open"], vec!["next"], vec!["prev"], vec!["quit"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#"set "arg 1""#).unwrap(),
+            tokenize_operation_sequence(r#"set "arg 1""#).unwrap().0,
             vec![vec!["set", "arg 1"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#"set "arg 1" ; set "arg 2" "arg 3""#).unwrap(),
+            tokenize_operation_sequence(r#"set "arg 1" ; set "arg 2" "arg 3""#)
+                .unwrap()
+                .0,
             vec![vec!["set", "arg 1"], vec!["set", "arg 2", "arg 3"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#"set browser "firefox"; open-in-browser"#).unwrap(),
+            tokenize_operation_sequence(r#"set browser "firefox"; open-in-browser"#)
+                .unwrap()
+                .0,
             vec![vec!["set", "browser", "firefox"], vec!["open-in-browser"]]
         );
         assert_eq!(
-            tokenize_operation_sequence("set browser firefox; open-in-browser").unwrap(),
+            tokenize_operation_sequence("set browser firefox; open-in-browser")
+                .unwrap()
+                .0,
             vec![vec!["set", "browser", "firefox"], vec!["open-in-browser"]]
         );
         assert_eq!(
-            tokenize_operation_sequence("open-in-browser; quit").unwrap(),
+            tokenize_operation_sequence("open-in-browser; quit")
+                .unwrap()
+                .0,
             vec![vec!["open-in-browser"], vec!["quit"]]
         );
         assert_eq!(
             tokenize_operation_sequence(r#"open; set browser "firefox --private-window"; quit"#)
-                .unwrap(),
+                .unwrap()
+                .0,
             vec![
                 vec!["open"],
                 vec!["set", "browser", "firefox --private-window"],
@@ -142,7 +155,8 @@ mod tests {
         );
         assert_eq!(
             tokenize_operation_sequence(r#"open ;set browser "firefox --private-window" ;quit"#)
-                .unwrap(),
+                .unwrap()
+                .0,
             vec![
                 vec!["open"],
                 vec!["set", "browser", "firefox --private-window"],
@@ -151,7 +165,8 @@ mod tests {
         );
         assert_eq!(
             tokenize_operation_sequence(r#"open;set browser "firefox --private-window";quit"#)
-                .unwrap(),
+                .unwrap()
+                .0,
             vec![
                 vec!["open"],
                 vec!["set", "browser", "firefox --private-window"],
@@ -159,42 +174,47 @@ mod tests {
             ]
         );
         assert_eq!(
-            tokenize_operation_sequence("; ;; ; open",).unwrap(),
+            tokenize_operation_sequence("; ;; ; open",).unwrap().0,
             vec![vec!["open"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(";;; ;; ; open",).unwrap(),
+            tokenize_operation_sequence(";;; ;; ; open",).unwrap().0,
             vec![vec!["open"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(";;; ;; ; open ;",).unwrap(),
+            tokenize_operation_sequence(";;; ;; ; open ;",).unwrap().0,
             vec![vec!["open"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(";;; ;; ; open ;; ;",).unwrap(),
+            tokenize_operation_sequence(";;; ;; ; open ;; ;",)
+                .unwrap()
+                .0,
             vec![vec!["open"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(";;; ;; ; open ; ;;;;",).unwrap(),
+            tokenize_operation_sequence(";;; ;; ; open ; ;;;;",)
+                .unwrap()
+                .0,
             vec![vec!["open"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(";;; open ; ;;;;",).unwrap(),
+            tokenize_operation_sequence(";;; open ; ;;;;",).unwrap().0,
             vec![vec!["open"]]
         );
         assert_eq!(
-            tokenize_operation_sequence("; open ;; ;; ;",).unwrap(),
+            tokenize_operation_sequence("; open ;; ;; ;",).unwrap().0,
             vec![vec!["open"]]
         );
         assert_eq!(
-            tokenize_operation_sequence("open ; ;;; ;;",).unwrap(),
+            tokenize_operation_sequence("open ; ;;; ;;",).unwrap().0,
             vec![vec!["open"]]
         );
         assert_eq!(
             tokenize_operation_sequence(
                 r#"set browser "sleep 3; do-something ; echo hi"; open-in-browser"#
             )
-            .unwrap(),
+            .unwrap()
+            .0,
             vec![
                 vec!["set", "browser", "sleep 3; do-something ; echo hi"],
                 vec!["open-in-browser"]
@@ -205,27 +225,27 @@ mod tests {
     #[test]
     fn t_tokenize_operation_sequence_ignores_escaped_sequences_outside_double_quotes() {
         assert_eq!(
-            tokenize_operation_sequence(r#"\t"#).unwrap(),
+            tokenize_operation_sequence(r#"\t"#).unwrap().0,
             vec![vec![r#"\t"#]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#"\r"#).unwrap(),
+            tokenize_operation_sequence(r#"\r"#).unwrap().0,
             vec![vec![r#"\r"#]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#"\n"#).unwrap(),
+            tokenize_operation_sequence(r#"\n"#).unwrap().0,
             vec![vec![r#"\n"#]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#"\v"#).unwrap(),
+            tokenize_operation_sequence(r#"\v"#).unwrap().0,
             vec![vec![r#"\v"#]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#"\""#).unwrap(),
+            tokenize_operation_sequence(r#"\""#).unwrap().0,
             vec![vec![r#"\""#]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#"\\"#).unwrap(),
+            tokenize_operation_sequence(r#"\\"#).unwrap().0,
             vec![vec![r#"\\"#]]
         );
     }
@@ -233,23 +253,23 @@ mod tests {
     #[test]
     fn t_tokenize_operation_sequence_expands_escaped_sequences_inside_double_quotes() {
         assert_eq!(
-            tokenize_operation_sequence(r#""\t""#).unwrap(),
+            tokenize_operation_sequence(r#""\t""#).unwrap().0,
             vec![vec!["\t"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#""\r""#).unwrap(),
+            tokenize_operation_sequence(r#""\r""#).unwrap().0,
             vec![vec!["\r"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#""\n""#).unwrap(),
+            tokenize_operation_sequence(r#""\n""#).unwrap().0,
             vec![vec!["\n"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#""\"""#).unwrap(),
+            tokenize_operation_sequence(r#""\"""#).unwrap().0,
             vec![vec!["\""]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#""\\""#).unwrap(),
+            tokenize_operation_sequence(r#""\\""#).unwrap().0,
             vec![vec!["\\"]]
         );
     }
@@ -258,23 +278,23 @@ mod tests {
     fn t_tokenize_operation_sequence_passes_through_unsupported_escaped_chars_inside_double_quotes()
     {
         assert_eq!(
-            tokenize_operation_sequence(r#""\1""#).unwrap(),
+            tokenize_operation_sequence(r#""\1""#).unwrap().0,
             vec![vec!["1"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#""\W""#).unwrap(),
+            tokenize_operation_sequence(r#""\W""#).unwrap().0,
             vec![vec!["W"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#""\b""#).unwrap(),
+            tokenize_operation_sequence(r#""\b""#).unwrap().0,
             vec![vec!["b"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#""\d""#).unwrap(),
+            tokenize_operation_sequence(r#""\d""#).unwrap().0,
             vec![vec!["d"]]
         );
         assert_eq!(
-            tokenize_operation_sequence(r#""\x""#).unwrap(),
+            tokenize_operation_sequence(r#""\x""#).unwrap().0,
             vec![vec!["x"]]
         );
     }
@@ -282,7 +302,7 @@ mod tests {
     #[test]
     fn t_tokenize_operation_sequence_implicitly_closes_double_quotes_at_end_of_input() {
         assert_eq!(
-            tokenize_operation_sequence(r#"set "arg 1"#).unwrap(),
+            tokenize_operation_sequence(r#"set "arg 1"#).unwrap().0,
             vec![vec!["set", "arg 1"]]
         );
     }
@@ -290,24 +310,27 @@ mod tests {
     #[test]
     fn t_tokenize_operation_sequence_allows_single_character_unquoted() {
         assert_eq!(
-            tokenize_operation_sequence(r#"set a b"#).unwrap(),
+            tokenize_operation_sequence(r#"set a b"#).unwrap().0,
             vec![vec!["set", "a", "b"]]
         );
     }
 
     #[test]
     fn t_tokenize_operation_sequence_does_not_consumpe_dashdash() {
-        assert_eq!(
-            tokenize_operation_sequence(r#"set a b -- "name of function""#).unwrap(),
-            vec![vec!["set", "a", "b"]]
-        );
+        let (operations, leftover) =
+            tokenize_operation_sequence(r#"set a b -- "name of function""#).unwrap();
+        assert_eq!(operations, vec![vec!["set", "a", "b"]]);
+        assert_eq!(leftover, r#" -- "name of function""#);
     }
 
     #[test]
     fn t_tokenize_operation_sequence_allows_dashdash_in_quoted() {
+        let (operations, leftover) =
+            tokenize_operation_sequence(r#"set a b "--" "name of function""#).unwrap();
         assert_eq!(
-            tokenize_operation_sequence(r#"set a b "--" "name of function""#).unwrap(),
+            operations,
             vec![vec!["set", "a", "b", "--", "name of function"]]
         );
+        assert_eq!(leftover, "");
     }
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -159,6 +159,7 @@ int Controller::run(const CliArgsParser& args)
 	colorman.register_commands(cfgparser);
 
 	KeyMap keys(KM_NEWSBOAT);
+	cfgparser.register_handler("bind", keys);
 	cfgparser.register_handler("bind-key", keys);
 	cfgparser.register_handler("unbind-key", keys);
 	cfgparser.register_handler("macro", keys);

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -728,10 +728,6 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 	} else if (action == "macro") {
 		std::string remaining_params = params;
 		const auto token = utils::extract_token_quoted(remaining_params);
-		// The token and operation sequence are delimited by one or more
-		// spaces. We have to strip them, or `parse_operation_sequence()` will
-		// include them into the first operation.
-		utils::trim(remaining_params);
 		const std::vector<MacroCmd> cmds = parse_operation_sequence(remaining_params);
 		if (!token.has_value() || cmds.empty()) {
 			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -689,7 +689,28 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 	 * configuration is immediately handed to it.
 	 */
 	LOG(Level::DEBUG, "KeyMap::handle_action(%s, ...) called", action);
-	if (action == "bind-key") {
+	if (action == "bind") {
+		std::string remaining_params = params;
+		const auto key_sequence = utils::extract_token_quoted(remaining_params);
+		const auto context = utils::extract_token_quoted(remaining_params);
+		const auto parsed = parse_operation_sequence(remaining_params);
+		const auto operations = parsed.operations;
+		const auto description = parse_operation_description(parsed.leftovers);
+		if (context.has_value() && key_sequence.has_value()) {
+			std::cout << std::endl;
+			std::cout << std::endl;
+			std::cout << "bind context=" << context.value() << " keys=" <<
+				key_sequence.value() << " description=" << description << std::endl;
+			for (const auto& operation : operations) {
+				std::cout << "    " << getopname(operation.op);
+				for (const auto& arg : operation.args) {
+					std::cout << " " << arg;
+				}
+				std::cout << std::endl;
+			}
+			std::cout << std::endl;
+		}
+	} else if (action == "bind-key") {
 		const auto tokens = utils::tokenize_quoted(params);
 		if (tokens.size() < 2) {
 			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -810,6 +810,21 @@ std::string KeyMap::parse_operation_description(const std::string& input)
 	return std::string(description);
 }
 
+std::vector<Key> KeyMap::parse_key_sequence(const std::string& input)
+{
+	const auto key_sequence_rs = keymap::bridged::tokenize_key_sequence(input);
+	std::vector<Key> key_sequence;
+	for (const auto& key_rs : key_sequence_rs) {
+		Key k;
+		k.key = std::string(keymap::bridged::get_key(key_rs));
+		k.shift = keymap::bridged::get_shift(key_rs);
+		k.control = keymap::bridged::get_control(key_rs);
+		k.meta = keymap::bridged::get_meta(key_rs);
+		key_sequence.push_back(k);
+	}
+	return key_sequence;
+}
+
 std::vector<MacroCmd> KeyMap::get_startup_operation_sequence()
 {
 	return startup_operations_sequence;

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -691,25 +691,28 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 	LOG(Level::DEBUG, "KeyMap::handle_action(%s, ...) called", action);
 	if (action == "bind") {
 		std::string remaining_params = params;
-		const auto key_sequence = utils::extract_token_quoted(remaining_params);
+		const auto key_sequence_text = utils::extract_token_quoted(remaining_params);
 		const auto context = utils::extract_token_quoted(remaining_params);
+		if (!key_sequence_text.has_value() || !context.has_value()) {
+			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
+		}
+		const auto key_sequence = parse_key_sequence(key_sequence_text.value());
 		const auto parsed = parse_operation_sequence(remaining_params);
 		const auto operations = parsed.operations;
 		const auto description = parse_operation_description(parsed.leftovers);
-		if (context.has_value() && key_sequence.has_value()) {
-			std::cout << std::endl;
-			std::cout << std::endl;
-			std::cout << "bind context=" << context.value() << " keys=" <<
-				key_sequence.value() << " description=" << description << std::endl;
-			for (const auto& operation : operations) {
-				std::cout << "    " << getopname(operation.op);
-				for (const auto& arg : operation.args) {
-					std::cout << " " << arg;
-				}
-				std::cout << std::endl;
+		std::cout << std::endl;
+		std::cout << std::endl;
+		std::cout << "bind context=" << context.value() << " keys=" <<
+			key_sequence_text.value() << " description=" << description << std::endl;
+		for (const auto& operation : operations) {
+			std::cout << "    " << getopname(operation.op);
+			for (const auto& arg : operation.args) {
+				std::cout << " " << arg;
 			}
 			std::cout << std::endl;
 		}
+		std::cout << std::endl;
+		register_binding(context.value(), key_sequence, operations, description);
 	} else if (action == "bind-key") {
 		const auto tokens = utils::tokenize_quoted(params);
 		if (tokens.size() < 2) {
@@ -881,6 +884,17 @@ unsigned short KeyMap::get_flag_from_context(const std::string& context)
 	}
 
 	return 0; // shouldn't happen
+}
+
+void KeyMap::register_binding(const std::string& context,
+	std::vector<Key> key_sequence, std::vector<MacroCmd> operations,
+	const std::string description)
+{
+	// TODO: Implement
+	(void)context;
+	(void)key_sequence;
+	(void)operations;
+	(void)description;
 }
 
 } // namespace newsboat

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -701,6 +701,14 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 		}
 		const auto key_sequence = parse_key_sequence(key_sequence_text.value());
+		if (key_sequence.empty()) {
+			throw ConfigHandlerException(strprintf::fmt(
+					_("`%s' is not a valid key sequence"),
+					key_sequence_text.value()));
+		}
+		const auto key = key_sequence.back();
+		const auto key_prefix = std::vector<Key>(key_sequence.begin(),
+				std::prev(key_sequence.end()));
 		const auto parsed = parse_operation_sequence(remaining_params);
 		const auto operations = parsed.operations;
 		const auto description = parse_operation_description(parsed.leftovers);
@@ -716,14 +724,7 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 			std::cout << std::endl;
 		}
 		std::cout << std::endl;
-		if (!key_sequence.empty()) {
-			const auto key = key_sequence.back();
-			const auto key_prefix = std::vector<Key>(key_sequence.begin(),
-					std::prev(key_sequence.end()));
-			register_binding(context.value(), key_prefix, key, operations, description);
-		} else {
-			// TODO: Throw ConfigHandlerException?
-		}
+		register_binding(context.value(), key_prefix, key, operations, description);
 	} else if (action == "bind-key") {
 		const auto tokens = utils::tokenize_quoted(params);
 		if (tokens.size() < 2) {
@@ -904,6 +905,7 @@ void KeyMap::register_binding(const std::string& context,
 	auto context_root = bindings_[context];
 	if (context_root == nullptr) {
 		// TODO: Handle unknown context
+		std::cout << "Unknown context: " << context << std::endl;
 		return;
 	}
 

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -728,7 +728,13 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 	} else if (action == "macro") {
 		std::string remaining_params = params;
 		const auto token = utils::extract_token_quoted(remaining_params);
-		const std::vector<MacroCmd> cmds = parse_operation_sequence(remaining_params);
+		const auto parsed = parse_operation_sequence(remaining_params);
+		const std::vector<MacroCmd> cmds = parsed.operations;
+		remaining_params = parsed.leftovers;
+		if (!remaining_params.empty()) {
+			LOG(Level::DEBUG,
+				"KeyMap::handle_action(macro): ignored remainder:  \"%s\"", remaining_params);
+		}
 		if (!token.has_value() || cmds.empty()) {
 			throw ConfigHandlerException(ActionHandlerStatus::TOO_FEW_PARAMS);
 		}
@@ -736,16 +742,18 @@ void KeyMap::handle_action(const std::string& action, const std::string& params)
 
 		macros_[macrokey] = cmds;
 	} else if (action == "run-on-startup") {
-		startup_operations_sequence = parse_operation_sequence(params);
+		startup_operations_sequence = parse_operation_sequence(params).operations;
 	} else {
 		throw ConfigHandlerException(ActionHandlerStatus::INVALID_PARAMS);
 	}
 }
 
 
-std::vector<MacroCmd> KeyMap::parse_operation_sequence(const std::string& line)
+ParsedOperations KeyMap::parse_operation_sequence(const std::string& line)
 {
-	const auto operations = keymap::bridged::tokenize_operation_sequence(line);
+	rust::String leftovers;
+	const auto operations = keymap::bridged::tokenize_operation_sequence(line,
+			leftovers);
 
 	std::vector<MacroCmd> cmds;
 	for (const auto& operation : operations) {
@@ -769,7 +777,10 @@ std::vector<MacroCmd> KeyMap::parse_operation_sequence(const std::string& line)
 		cmds.push_back(cmd);
 	}
 
-	return cmds;
+	return ParsedOperations{
+		.operations = cmds,
+		.leftovers = std::string(leftovers)
+	};
 }
 
 std::vector<MacroCmd> KeyMap::get_startup_operation_sequence()

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -783,6 +783,12 @@ ParsedOperations KeyMap::parse_operation_sequence(const std::string& line)
 	};
 }
 
+std::string KeyMap::parse_operation_description(const std::string& input)
+{
+	const auto description = keymap::bridged::tokenize_operation_description(input);
+	return std::string(description);
+}
+
 std::vector<MacroCmd> KeyMap::get_startup_operation_sequence()
 {
 	return startup_operations_sequence;

--- a/src/pbcontroller.cpp
+++ b/src/pbcontroller.cpp
@@ -280,6 +280,7 @@ void PbController::initialize(int argc, char* argv[])
 	cfgparser.register_handler("unbind-key", keys);
 
 	NullConfigActionHandler null_cah;
+	cfgparser.register_handler("bind", null_cah);
 	cfgparser.register_handler("macro", null_cah);
 	cfgparser.register_handler("ignore-article", null_cah);
 	cfgparser.register_handler("always-download", null_cah);


### PR DESCRIPTION
Working on implementation for https://github.com/newsboat/newsboat/issues/1165.

I'm using this PR as a place to keep track of TODOs.
When it is ready for full review, I will open a PR on the original Newsboat repo.

TODO:
- [x] Parse (optional) description for binding
- [x] Parse+validate key sequences (including support for modifier keys using `<C-S-M-d>` notation)
- [ ] Determine which named keys to support (e.g. "enter", "space", "up", "down", "left", "right", …)
- [x] Create structure for storing key sequences
- [ ] Implement key-sequence/map in Rust?
- [x] Validate contexts
- [ ] Show queued inputs
- [ ] Show binds in help form
- [ ] Show bind's description in help form
- [ ] Add Rust tests for new functionality
- [ ] Add C++ tests for new Rust (FFI-)functions